### PR TITLE
Support Minecraft 1.19.x

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '0.10-SNAPSHOT'
+    id 'fabric-loom' version '0.12-SNAPSHOT'
 }
 
 sourceCompatibility = JavaVersion.VERSION_17

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,10 +1,10 @@
 org.gradle.jvmargs=-Xmx1G
 org.gradle.daemon=false
 
-minecraft_version=1.18.1
-yarn_mappings=1.18.1+build.1
-loader_version=0.12.12
+minecraft_version=1.19
+yarn_mappings=1.19+build.4
+loader_version=0.14.9
 
-mod_version=1.2.1
+mod_version=1.2.2
 maven_group=ewewukek.tpc
 archives_base_name=ThirdPersonCrosshair

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -14,7 +14,7 @@
     "tpcrosshair.mixins.json"
   ],
   "depends": {
-    "minecraft": "1.18.x",
+    "minecraft": "1.19.x",
     "java": ">=17",
     "fabricloader": ">=0.11.3"
   }


### PR DESCRIPTION
Hi,

Here is a simple patch to upgrade to 1.19 support.